### PR TITLE
refactor: TxClient & TxContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ async def main():
     # build tx_client_deps_ref... see dependency construction example above.
 
     # Gateway 2 tx client (gateway2 SHOULD NOT be staked)
-    gw_tx_client = TxClient(tx_client_deps_ref, "gateway2")
+    gw_tx_client = TxClient("gateway2", tx_client_deps_ref)
 
     # Application 3 tx client (app3 SHOULD NOT be staked)
-    app_tx_client = TxClient(tx_client_deps_ref, "app3")
+    app_tx_client = TxClient("app3", tx_client_deps_ref)
 
     # Stake localnet gateway 2
     await gw_tx_client.sign_and_broadcast(

--- a/src/poktroll_clients/__init__.py
+++ b/src/poktroll_clients/__init__.py
@@ -2,7 +2,8 @@
 from os import path
 
 from .block_client import BlockClient, BlockQueryClient
-from .tx_client import TxContext, TxClient
+from .tx_context import TxContext
+from .tx_client import TxClient
 from .events_query_client import EventsQueryClient
 from .depinject import Supply, SupplyMany
 from .go_memory import go_ref

--- a/src/poktroll_clients/block_client.py
+++ b/src/poktroll_clients/block_client.py
@@ -10,13 +10,13 @@ class BlockClient(GoManagedMem):
     go_ref: go_ref
     err_ptr: ffi.CData
 
-    def __init__(self, cfg_ref: go_ref):
+    def __init__(self, deps_ref: go_ref):
         """
         Constructor for BlockClient.
-        :param cfg_ref: A Go-managed memory reference to a depinject config.
+        :param deps_ref: A Go-managed memory reference to a depinject config.
         """
 
-        go_ref = libpoktroll_clients.NewBlockClient(cfg_ref, self.err_ptr)
+        go_ref = libpoktroll_clients.NewBlockClient(deps_ref, self.err_ptr)
         super().__init__(go_ref)
 
 

--- a/src/poktroll_clients/depinject.py
+++ b/src/poktroll_clients/depinject.py
@@ -10,12 +10,12 @@ def Supply(go_ref: go_ref) -> go_ref:
     """
 
     err_ptr = ffi.new("char **")
-    cfg_ref = libpoktroll_clients.Supply(go_ref, err_ptr)
+    deps_ref = libpoktroll_clients.Supply(go_ref, err_ptr)
 
     check_err(err_ptr)
-    check_ref(cfg_ref)
+    check_ref(deps_ref)
 
-    return cfg_ref
+    return deps_ref
 
 
 def SupplyMany(*go_objs: GoManagedMem) -> go_ref:
@@ -29,9 +29,9 @@ def SupplyMany(*go_objs: GoManagedMem) -> go_ref:
     cgo_refs = ffi.new("go_ref[]", go_refs)
     err_ptr = ffi.new("char **")
 
-    cfg_ref = libpoktroll_clients.SupplyMany(cgo_refs, len(go_objs), err_ptr)
+    deps_ref = libpoktroll_clients.SupplyMany(cgo_refs, len(go_objs), err_ptr)
 
     check_err(err_ptr)
-    check_ref(cfg_ref)
+    check_ref(deps_ref)
 
-    return cfg_ref
+    return deps_ref

--- a/src/poktroll_clients/ffi.py
+++ b/src/poktroll_clients/ffi.py
@@ -86,9 +86,9 @@ ffi.cdef("""
 
     go_ref NewTxContext(char *tcp_url, char **err);
 
-    go_ref NewBlockClient(go_ref cfg_ref, char **err);
+    go_ref NewBlockClient(go_ref deps_ref, char **err);
 
-    go_ref NewTxClient(go_ref cfg_ref, char *signing_key_name, char **err);
+    go_ref NewTxClient(go_ref deps_ref, char *signing_key_name, char **err);
     go_ref TxClient_SignAndBroadcast(AsyncOperation* op, go_ref self_ref, serialized_proto *msg);
     go_ref TxClient_SignAndBroadcastMany(AsyncOperation* op, go_ref self_ref, proto_message_array *msgs);
 """)

--- a/src/poktroll_clients/tx_context.py
+++ b/src/poktroll_clients/tx_context.py
@@ -1,0 +1,20 @@
+from poktroll_clients.ffi import ffi, libpoktroll_clients
+from poktroll_clients.go_memory import GoManagedMem, go_ref
+
+
+class TxContext(GoManagedMem):
+    """
+    TODO_IN_THIS_COMMIT: comment
+    """
+
+    go_ref: go_ref
+    err_ptr: ffi.CData
+
+    def __init__(self, tx_node_rpc_url: str):
+        """
+        Constructor for TxContext.
+        :param tx_node_rpc_url: The gRPC URL for the client to use (e.g. tcp://127.0.0.1:26657).
+        """
+
+        go_ref = libpoktroll_clients.NewTxContext(tx_node_rpc_url.encode('utf-8'), self.err_ptr)
+        super().__init__(go_ref)

--- a/tests/test_block_client.py
+++ b/tests/test_block_client.py
@@ -14,5 +14,5 @@ def test_block_query_client():
 def test_block_client():
     events_query_client = EventsQueryClient("ws://127.0.0.1:26657/websocket")
     block_query_client = BlockQueryClient("http://127.0.0.1:26657")
-    cfg_ref = SupplyMany(events_query_client, block_query_client)
-    block_client = BlockClient(cfg_ref)
+    deps_ref = SupplyMany(events_query_client, block_query_client)
+    block_client = BlockClient(deps_ref)

--- a/tests/test_depinject.py
+++ b/tests/test_depinject.py
@@ -7,7 +7,7 @@ from poktroll_clients import (
 
 def test_depinject_supply():
     client = EventsQueryClient("ws://127.0.0.1:26657/websocket")
-    cfg_ref = Supply(client.go_ref)
+    deps_ref = Supply(client.go_ref)
 
 
 def test_depinject_supply_many():

--- a/tests/test_tx_client.py
+++ b/tests/test_tx_client.py
@@ -22,14 +22,14 @@ def test_tx_context():
 
 
 def test_tx_client():
-    cfg_ref = get_tx_client_deps()
-    tx_client = TxClient(cfg_ref, "faucet")
+    deps_ref = get_tx_client_deps()
+    tx_client = TxClient("faucet", deps_ref)
 
 
 @pytest.mark.asyncio
 async def test_sign_and_broadcast_success():
-    cfg_ref = get_tx_client_deps()
-    tx_client = TxClient(cfg_ref, "pnf")
+    deps_ref = get_tx_client_deps()
+    tx_client = TxClient("pnf", deps_ref)
 
     send_msg_from_pnf_to_app3 = MsgSend(
         from_address="pokt1eeeksh2tvkh7wzmfrljnhw4wrhs55lcuvmekkw",
@@ -45,9 +45,9 @@ async def test_sign_and_broadcast_success():
 
 @pytest.mark.asyncio
 async def test_sign_and_broadcast_many_success():
-    cfg_ref = get_tx_client_deps()
-    app3_tx_client = TxClient(cfg_ref, "app3")
-    gateway2_tx_client = TxClient(cfg_ref, "gateway2")
+    deps_ref = get_tx_client_deps()
+    app3_tx_client = TxClient("app3", deps_ref)
+    gateway2_tx_client = TxClient("gateway2", deps_ref)
 
     app3_addr = "pokt1lqyu4v88vp8tzc86eaqr4lq8rwhssyn6rfwzex"
     gateway2_addr = "pokt15w3fhfyc0lttv7r585e2ncpf6t2kl9uh8rsnyz"
@@ -90,8 +90,8 @@ async def test_sign_and_broadcast_many_success():
 
 @pytest.mark.asyncio
 async def test_sign_and_broadcast_error():
-    cfg_ref = get_tx_client_deps()
-    tx_client = TxClient(cfg_ref, "app1")
+    deps_ref = get_tx_client_deps()
+    tx_client = TxClient("app1", deps_ref)
 
     # Attempt to stake an already-staked address (app1)
     stake_app1_msg = MsgStakeApplication(
@@ -109,8 +109,8 @@ def get_tx_client_deps() -> go_ref:
     events_query_client = EventsQueryClient("ws://127.0.0.1:26657/websocket")
     block_query_client = BlockQueryClient("http://127.0.0.1:26657")
 
-    cfg_ref = SupplyMany(events_query_client, block_query_client)
-    block_client = BlockClient(cfg_ref)
+    deps_ref = SupplyMany(events_query_client, block_query_client)
+    block_client = BlockClient(deps_ref)
 
     tx_ctx = TxContext("tcp://127.0.0.1:26657")
 


### PR DESCRIPTION
### Changes

- Update `TxClient` constructor to take depinject config ref as positional arg or kwarg.
- Added `query_node_rpc_url` and `tx_node_rpc_url` kwargs to the `TxClient` constructor.
- Renamed `cfg_ref` variables to `deps_ref` for consistency with poktroll go code.
- Promoted `TxContext to its own file.
- Updated imports (more granular) to work around cyclic import on `poktroll_clients` during initialization.